### PR TITLE
fix:set c99 flag so gcc will compile cython code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ extensions = [
     Extension(
         'oscar', libraries=['bz2', 'z'], include_dirs=['lib'],
         sources=['oscar.pyx',
-                 'lib/tchdb.c', 'lib/myconf.c', 'lib/tcutil.c', 'lib/md5.c']
+                 'lib/tchdb.c', 'lib/myconf.c', 'lib/tcutil.c', 'lib/md5.c'],
+        extra_compile_args=['-std=c99']
     ),
 ]
 


### PR DESCRIPTION
Got compile errors when compiling with `python3 setup.py build_ext --inplace`.  This seems to fix the problem by directing gcc to use c99 mode.