### PR TITLE
fix: Python2 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
     - name: Build manylinux package
       # manylinux2014_x86_64 doesn't support Python 2,
       # use the default manylinux2010_x86_64
-      uses: RalfG/python-wheels-manylinux-build@v0.3.3
+      uses: user2589/python-wheels-manylinux-build@master
       with:
-        python-versions: 'cp36-cp36m'
+        python-versions: 'cp27-cp27mu cp36-cp36m'
         build-requirements: 'cython setuptools>=18.0'
         system-packages: 'bzip2-devel zlib-devel'
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 # https://github.com/RalfG/python-wheels-manylinux-build
 .PHONY: build_manylinux
 build_manylinux:
-	docker run --rm -e PLAT=manylinux2010_x86_64 -v `pwd`:/github/workspace/ quay.io/pypa/manylinux2010_x86_64 "cp27-cp27m cp36-cp36m" "cython setuptools>=18.0" "bzip2-devel zlib-devel"
+	docker run --rm -e PLAT=manylinux2010_x86_64 -v `pwd`:/github/workspace/ python-wheels-manylinux-build "cp27-cp27m cp36-cp36m" "cython setuptools>=18.0" "bzip2-devel zlib-devel"
 
 .PHONY: test
 test:

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -96,9 +96,9 @@ a special Docker image, and is automated via GitHub action.
 To build package locally,
 
 #. clone the corresponding GitHub action repository,
-   `git clone git@github.com:RalfG/python-wheels-manylinux-build.git`,
-#. check out the desired tag if necessary, e.g. `git checkout v0.3.3`
-#. build Docker image: `docker build -t manylinux2010 .`
+   `git clone git@github.com:user2589/python-wheels-manylinux-build.git`,
+#. check out the desired tag if necessary, e.g. `git checkout v0.3.4`
+#. build Docker image: `docker build -t ython-wheels-manylinux-build .`
 #. run the image: `make build_manylinux`
 
 


### PR DESCRIPTION
Manylinux image dropped Python2 support in version quay.io/pypamanylinux2010_x86_64:2021-02-07-7816579 . The previously used [release action](https://github.com/RalfG/python-wheels-manylinux-build) uses the latest manylinux image, thus it lost Python2 compatibility, too.

Solution:
[fork](https://github.com/user2589/python-wheels-manylinux-build) the release github action, using the latest manylinux release before Py2 support was dropped (quay.io/pypa/manylinux2010_x86_64:2021-02-06-3d322a5)