### PR TITLE
Fail gracefully if some commit in a project is empty

### DIFF
--- a/oscar.pyx
+++ b/oscar.pyx
@@ -1053,7 +1053,10 @@ class Commit(GitObject):
     #     self.parent_shas = tuple(parent_shas)
 
     def _parse(self):
-        self.header, self.full_message = self.data.split(b'\n\n', 1)
+        try:
+            self.header, self.full_message = self.data.split(b'\n\n', 1)
+        except ValueError:   # Sometimes self.data == b''
+            raise ObjectNotFound()
         self.message = self.full_message.split(b'\n', 1)[0]
         cdef list parent_shas = []
         cdef bytes signature = None


### PR DESCRIPTION
This Python3 program:
```
import oscar

commits = list(oscar.Project("ZieIony_Carbon"))
print(len(commits))
```

Returns this error:
```
Traceback (most recent call last):
  File "example.py", line 3, in <module>
    commits = list(oscar.Project("ZieIony_Carbon"))
  File "oscar.pyx", line 1363, in __iter__
    author = c.author
  File "oscar.pyx", line 949, in oscar.Commit.__getattr__
    self._parse()
  File "oscar.pyx", line 1056, in oscar.Commit._parse
    self.header, self.full_message = self.data.split(b'\n\n', 1)
ValueError: need more than 1 value to unpack
```

because self.data is empty in some cases.  This PR is a proposed fix.