### PR TITLE
Add support for multi-char versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Python interface for OSCAR data
 
+> [!NOTE]
+> New projects may want to use the [python-woc](https://github.com/ssc-oscar/python-woc) package instead. It's fast, easy to install, and provides a more complete interface to the data.
 
 This is a convenience library to access World of Code data
 (WoC; it was referred internally as oscar while development, hence the name). 

--- a/oscar.pyx
+++ b/oscar.pyx
@@ -79,14 +79,30 @@ def _key_length(str path_template):
         return 0
     glob_pattern = path_template.format(key='*', ver='*')
     filenames = glob.glob(glob_pattern)
+
+    # check emptiness of filenames otherwise we can't use filenames[0]
+    if not filenames:
+        # warnings.warn("No files found for %s" % (glob_pattern))
+        return 0
+
     # key always comes the last, so rsplit is enough to account for two stars
     prefix, postfix = glob_pattern.rsplit('*', 1)
+
+    # quirk for multi-char versions: match the last digit of the prefix
+    _prefix_len = len(prefix)
+    while _prefix_len < len(filenames[0]) - 2:
+        if filenames[0][_prefix_len - 1] == prefix[len(prefix) - 1]:
+            break
+        _prefix_len += 1
+
     # note that with wraparound=False we can't use negative indexes.
     # this caused hard to catch bugs before
-    str_keys = [fname[len(prefix):len(fname)-len(postfix)] for fname in filenames]
+    str_keys = [fname[_prefix_len:len(fname)-len(postfix)] for fname in filenames]
     keys = [int(key) for key in str_keys if key]
     # Py2/3 compatible version
     return int(log(max(keys or [0]) + 1, 2))
+    # re_pattern = path_template.format(key='(\d+)', ver='([A-Za-z0-9]+)')
+    # _matched = re.match(re_pattern, 'c2cFull{ver}.0.tch')
 
 
 # this dict is only for debugging purposes and it is not used anywhere

--- a/oscar.pyx
+++ b/oscar.pyx
@@ -22,7 +22,7 @@ import warnings
 # `pip uninstall lzf && pip install python-lzf`
 import lzf
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 __author__ = 'marat@cmu.edu'
 __license__ = 'GPL v3'
 


### PR DESCRIPTION
Closes #55. 

This PR changes:
- Adds support for multi-char versions
- Allows using different versions of maps simultaneously (some on V, some on V3)
- Fixes path substitution (won't search for /da*_data/basemaps_fast/ anymore)
- Adds a link to python-woc in README
- Bumps version to 2.2.2
